### PR TITLE
Add $dume, execute on method

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ Useful for:
 
 Like `$dum` but logs arguments instead.
 
+### $dume(object, method, callback)
+
+Executes `callback` when the method is invoked.
+
 ### $dumr(object, method)
 
 Removes debug or log wrappers added by `$dum` or `$duml`.

--- a/test/test.js
+++ b/test/test.js
@@ -74,7 +74,7 @@ describe('$duv, $duvl, $duvr', function() {
 
 });
 
-describe('$dum, $duml, $dumr', function() {
+describe('$dum, $duml, $dume, $dumr', function() {
 
   beforeEach(function() {
     this.obj = {
@@ -95,6 +95,18 @@ describe('$dum, $duml, $dumr', function() {
     du.$duml(this.obj, 'foo');
     assert(this.obj.foo.toString().match(/console.log/));
     assert.equal(this.obj.foo(1, 2, 3), 6);
+  });
+
+  it('should call custom callback', function() {
+    var called = false;
+
+    du.$dume(this.obj, 'foo', function() {
+      called = true;
+    });
+
+    this.obj.foo(1, 2, 3);
+
+    assert.ok(called);
   });
 
   it('should removed wrapped method', function() {


### PR DESCRIPTION
Allows an arbitrary callback to be invoked prior to the real method executing.

I added this out of a desire to log a custom message when the method is invoked, instead of the default behavior of `$duml`. I could envision it being used for other things, so I'm submitting it here.
