### PR TITLE
Added human readable methods.

### DIFF
--- a/du.js
+++ b/du.js
@@ -8,18 +8,38 @@ var exports = {
   $duv: $duv,
   $duvl: $duvl,
   $duvr: $duvr,
+  $duEvent: $duv,
+  $duEventLogger: $duvl,
+  $duEventRemove: $duvr,
+
   $dum: $dum,
   $duml: $duml,
   $dumr: $dumr,
+  $duWrapMethod: $dum,
+  $duWrapMethodLogger: $duml,
+  $duWrapMethodRemove: $dumr,
+
   $dug: $dug,
   $dugl: $dugl,
   $dugr: $dugr,
+  $duGetter: $dug,
+  $duGetterLogger: $dugl,
+  $duGetterRemove: $dugr,
+
   $dus: $dus,
   $dusl: $dusl,
   $dusr: $dusr,
+  $duAccessor: $dus,
+  $duAccessorLogger: $dusl,
+  $duAccessorRemove: $dusr,
+
   $dugs: $dugs,
   $dugsl: $dugsl,
   $dugsr: $dugsr,
+  $duSetter: $dugs,
+  $duSetterLogger: $dugsl,
+  $duSetterRemove: $dugsr,
+
   $dudebug: $dudebug,
   $dulog: $dulog,
   $dulogm: $dulogm

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,28 @@ describe('install', function() {
     assert(context.$duv && context.$dum && context.$dus);
   });
 
+  it('should install all the human readable functions on the global NS', function() {
+    this.run();
+    var context = this.context;
+    assert(
+      context.$duEvent &&
+      context.$duEventLogger &&
+      context.$duEventRemove &&
+      context.$duWrapMethod &&
+      context.$duWrapMethodLogger &&
+      context.$duWrapMethodRemove &&
+	  context.$duGetter &&
+	  context.$duGetterLogger &&
+	  context.$duGetterRemove &&
+	  context.$duAccessor &&
+	  context.$duAccessorLogger &&
+	  context.$duAccessorRemove &&
+	  context.$duSetter &&
+	  context.$duSetterLogger &&
+	  context.$duSetterRemove
+	);
+  });
+
   it('should handle conflicts', function() {
     this.sandbox.$dum = 'foo';
     this.run();


### PR DESCRIPTION
Added methods that have more memorable names, or at least will be readable
so that developers don't need to remember things like "s is for Accessor".

Closes amasad/debug_utils#11
